### PR TITLE
sanitycheck: correct ELF path when getting ram size

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -5,7 +5,7 @@ compiler: gcc
 env:
     global:
         - SDK=0.9.1
-        - SANITYCHECK_OPTIONS=" --inline-logs -R --no-update -p nrf52_pca10040 -T samples/bluetooth/"
+        - SANITYCHECK_OPTIONS=" --inline-logs -R -p nrf52_pca10040 -T samples/bluetooth/"
         - SANITYCHECK_OPTIONS_RETRY="${SANITYCHECK_OPTIONS} --only-failed --outdir=out-2nd-pass"
         - ZEPHYR_SDK_INSTALL_DIR=/opt/sdk/zephyr-sdk-0.9.1
         - ZEPHYR_GCC_VARIANT=zephyr

--- a/scripts/sanitycheck
+++ b/scripts/sanitycheck
@@ -1220,7 +1220,7 @@ class TestInstance:
 
         @return A SizeCalculator object
         """
-        fns = glob.glob(os.path.join(self.outdir, "*.elf"))
+        fns = glob.glob(os.path.join(self.outdir, "zephyr", "*.elf"))
         fns = [x for x in fns if not x.endswith('_prebuilt.elf')]
         if (len(fns) != 1):
             raise BuildError("Missing/multiple output ELF binary")


### PR DESCRIPTION
The Zephyr elf is now under outdir/zephyr

Signed-off-by: Anas Nashif <anas.nashif@intel.com>